### PR TITLE
cassandra: fix beta annotation

### DIFF
--- a/addons/cassandra/0.x/cassandra.yaml
+++ b/addons/cassandra/0.x/cassandra.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "3.11.5-1"
     appversion.kubeaddons.mesosphere.io/cassandra: "3.11.5"
-    stage.kubeaddons.io/cassandra: Beta
+    stage.kubeaddons.mesosphere.io/cassandra: Beta
 spec:
   kubernetes:
     minSupportedVersion: v1.16.0


### PR DESCRIPTION
catalog UI will use annotation `stage.kubeaddons.mesosphere.io/<app-name>: Beta` 
This PR fixes the Cassandra annotation to match it with others like Spark and Dispatch in base-addons repository 