### PR TITLE
jenkins.yaml : fix yaml typo for jenkins ingress

### DIFF
--- a/addons/jenkins/1.x/jenkins.yaml
+++ b/addons/jenkins/1.x/jenkins.yaml
@@ -43,6 +43,6 @@ spec:
         jenkinsUriPrefix: "/jenkins"
         ingress:
           enabled: true
-        path: /jenkins
-        annotations:
-          kubernetes.io/ingress.class: traefik
+          path: /jenkins
+          annotations:
+            kubernetes.io/ingress.class: traefik


### PR DESCRIPTION
The ingress fields in jenkins chart values.yaml are not categorized correctly and this PR fixes that.