### PR TITLE
kafka: add default zookeeper URI override

### DIFF
--- a/addons/kafka/1.x/kafka-2.yaml
+++ b/addons/kafka/1.x/kafka-2.yaml
@@ -30,4 +30,8 @@ spec:
     repo: https://kudo-repository.storage.googleapis.com/0.10.0
     version: 1.2.0
     parameters: |
+      ZOOKEEPER_URI: zookeeper-zookeeper-0.zookeeper-hs:2181,zookeeper-zookeeper-1.zookeeper-hs:2181,zookeeper-zookeeper-2.zookeeper-hs:2181
+      # set the correct ZOOKEEPER_URI based on zookeeper service name
+      # e.g. for a zookeeper service with name 'zk1' and of 3 zk nodes the correct URI would be
+      # zk1-zookeeper-0.zk1-hs:2181,zk1-zookeeper-1.zk1-hs:2181,zk1-zookeeper-2.zk1-hs:2181
       ADD_SERVICE_MONITOR: true

--- a/metadata/static/cassandra/overview.md
+++ b/metadata/static/cassandra/overview.md
@@ -3,6 +3,8 @@ The Apache Cassandra database is the right choice when you need scalability and 
 
 The KUDO Cassandra operator creates, configures and manages Apache Cassandra clusters running on Kubernetes.
 
+Learn how to take full advantage of KUDO Cassandra in [docs](https://github.com/kudobuilder/operators/tree/master/repository/cassandra/3.11) available in [operators](https://github.com/kudobuilder/operators) repository
+
 ## Support Level
 This operator is in BETA and not supported yet.
 

--- a/metadata/static/kafka/overview.md
+++ b/metadata/static/kafka/overview.md
@@ -11,6 +11,8 @@ The KUDO Kafka operator creates, configures and manages Apache Kafka clusters ru
 - External access through LB/Nodeports
 - Mirror-maker integration
 
+Learn how to take full advantage of KUDO Kafka in [docs](https://github.com/kudobuilder/operators/tree/master/repository/kafka) available in [operators](https://github.com/kudobuilder/operators) repository
+
 ## Support Level
 - Mixed workload tested with 5 brokers, 4096Mib and 2000m each
   - 5Million msgs/sec with avg message size of 60 bytes

--- a/metadata/static/spark/overview.md
+++ b/metadata/static/spark/overview.md
@@ -14,6 +14,8 @@ The KUDO Spark Operator creates, configures, and manages instances of Spark Oper
 - Integration with external batch scheduler (Volcano)
 - External access to Spark UI through LB/Nodeports
 
+Learn how to take full advantage of KUDO Spark in [docs](https://github.com/kudobuilder/operators/tree/master/repository/spark) available in [operators](https://github.com/kudobuilder/operators) repository
+
 ## Support Level
 - Mixed workload tested with:
   - 50 operators

--- a/metadata/static/zookeeper/overview.md
+++ b/metadata/static/zookeeper/overview.md
@@ -4,6 +4,8 @@ The KUDO Zookeeper operator creates, configures and manages Apache Zookeeper clu
 - Graceful rolling updates for any cluster configuration changes
 - Graceful rolling upgrades when upgrading the operator version
 
+Learn how to take full advantage of KUDO Zookeeper in [docs](https://github.com/kudobuilder/operators/tree/master/repository/zookeeper) available in [operators](https://github.com/kudobuilder/operators) repository
+
 ## Support Level
 KUDO Zookeeper is only tested with KUDO Kafka 
 


### PR DESCRIPTION
when installing through kudo, we can just do a 
`kubectl kudo install zookeeper && kubectl kudo install kafka` and expect both operators to be healthy and up

When going through catalog UI and installing a zookeeper with name `zookeeper` and later proceeding to install `kafka` will fail, as kafka is expecting a `zookeeper-instance` by default. 

to improve the UX till the dependencies feature is resolved for KUDO we need to provide a clear way to configure zookeeper URIs that is intuitive when using KUDO Kafka through Catalog UI. And default installation of installing a zookeeper with name zookeeper and kafka with name kafka should work.

This PR also adds links to the docs of KUDO operators to the metadata