### PR TITLE
remove force-push to staging branch instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,8 @@ Pull Requests of feature branches should be opened against the `dev` branch.
 
 ### Staging Update (Second and Forth Thursday)
 
-On the second and forth _**Thursday**_, the `staging` should be updated. By setting `staging` branch to the head of `dev` and force-pushing.
+On the second and forth _**Thursday**_, the `staging` should be updated. By merging `dev` into `staging` branch.
+
 
 Verify in AWS Soak cluster, the workspace of `kudo-testing` 
 


### PR DESCRIPTION
small update on `RELEASE.md` 
we don't want to force-push to staging and rather detect merging conflicts from `dev` to `staging` then discovering them when opening the PR to `master` 