### PR TITLE
Bump to jenkins:2.6.4 and use upstream helm repo instead of default helm repo

### DIFF
--- a/addons/jenkins/1.x/jenkins.yaml
+++ b/addons/jenkins/1.x/jenkins.yaml
@@ -22,15 +22,15 @@ spec:
     - name: none
       enabled: true
   chartReference:
-    chart: stable/jenkins
-    version: 1.9.4
+    chart: jenkins
+    repo: https://charts.jenkins.io
+    version: 2.6.4
     values: |
       ---
       master:
-        useSecurity: false
         installPlugins:
           - prometheus:2.0.6
-          - kubernetes:1.18.2
+          - kubernetes:1.24.1
           - workflow-job:2.33
           - workflow-aggregator:2.6
           - credentials-binding:1.19
@@ -46,3 +46,6 @@ spec:
           path: /jenkins
           annotations:
             kubernetes.io/ingress.class: traefik
+        sidecars:
+          configAutoReload:
+            enabled: false


### PR DESCRIPTION
With current settings, the jenkins chart install is crashlooping kubeaddons controller with:
```
2020-11-10T18:45:38.523Z	ERROR	controller	Reconciler error	{"reconcilerGroup": "kubeaddons.mesosphere.io", "reconcilerKind": "Addon", "controller": "addon", "name": "jenkins", "namespace": "kudo-test-superb-anemone", "error": "deploy error: chart \"jenkins\" matching 1.9.4 not found in stable index. (try 'helm repo update'): no chart name found", "
```

[D2IQ-72758](https://jira.d2iq.com/browse/D2IQ-72758)