### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 * @mesosphere/sig-ksphere-catalog
 
-/addons/zookeeper/ @mesosphere/d2iq-k8s-workloads @nfnt @zmalik 
-/addons/kafka/ @mesosphere/d2iq-k8s-workloads @nfnt @zmalik
+/addons/zookeeper/ @mesosphere/d2iq-k8s-workloads @mesosphere/guild-data-services
+/addons/kafka/ @mesosphere/d2iq-k8s-workloads @mesosphere/guild-data-services
+/addons/cassandra/ @mesosphere/d2iq-k8s-workloads @mesosphere/guild-data-services
 /addons/jenkins/ @takirala @chhsia0
 /addons/spark/ @mesosphere/d2iq-k8s-workloads @akirillov @alembiewski


### PR DESCRIPTION
Adds @mesosphere/guild-data-services  team as code owners for `Kafka`, `Cassandra`, and `Zookeeper` repos.