### PR TITLE
Dispatch file integration

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -1,7 +1,8 @@
 #!mesosphere/dispatch-starlark:v0.6
 # vi:syntax=python
 load("github.com/mesosphere/dispatch-catalog/starlark/stable/pipeline@0.0.7", "cron")
-load("github.com/mesosphere/cluster-claim-controller/starlark/claim@master", "make_kind_cluster", "fetch_kubeconfig", "cleanup")
+load("github.com/mesosphere/cluster-claim-controller/starlark/claim@master",
+     "make_kind_cluster_claim", "fetch_kubeconfig", "release_claim")
 load("github.com/mesosphere/dispatch-tasks/bump_charts/bump_charts@master", "bump_charts")
 load("github.com/mesosphere/dispatch-catalog/starlark/stable/pipeline@0.0.4", "gitResource", "pullRequest", "push", "volume", "resourceVar", "secretVar")
 
@@ -9,12 +10,12 @@ git = "src-git"
 gitResource(git, url="$(context.git.url)", revision="$(context.git.commit)")
 
 cluster_name = "kubeaddons"
-kind_cluster=make_kind_cluster(cluster_name, git)
+kind_cluster=make_kind_cluster_claim(cluster_name, deps=[git])
 
 task("integration-test", inputs=[git],
      deps=[kind_cluster],
      steps=[
-       fetch_kubeconfig(cluster_name, git),
+       fetch_kubeconfig(cluster_name, git, name="fetch-config"),
        k8s.corev1.Container(
        name = "integration-tester",
               workingDir = "/workspace/{}/".format(git),
@@ -50,9 +51,14 @@ task("integration-test", inputs=[git],
      ]
 )
 
-kind_cleanup = cleanup(kind_cluster, "integration-test", git)
+kind_cleanup = release_claim(kind_cluster, "integration-test")
 do_bump_charts = bump_charts(repo_name="kubeaddons-enterprise", task_name="bump-charts")
 
+#Robot Actions
 action(name="bump-charts", on=cron(schedule="0 3 * * 5"), tasks=[do_bump_charts])
+
+#PRs
 action(tasks=["integration-test", kind_cleanup], on=pullRequest())
 
+#Chatops Actions
+action(tasks=["integration-test", kind_cleanup], on=pullRequest(chatops=["test"]))

--- a/Dispatchfile
+++ b/Dispatchfile
@@ -27,7 +27,7 @@ task("integration-test", inputs=[git],
                   export GOPRIVATE=github.com/mesosphere/kubeaddons
                   ssh-keyscan -t rsa github.com > /etc/ssh/known_hosts
                   git config --global url."https://$GITHUB_TOKEN:@github.com/".insteadOf "https://github.com/"
-                  make dispatch-test
+                  make kind-test
                   """
               ],
               resources = k8s.corev1.ResourceRequirements(

--- a/Dispatchfile
+++ b/Dispatchfile
@@ -27,7 +27,6 @@ task("integration-test", inputs=[git],
                   export GOPRIVATE=github.com/mesosphere/kubeaddons
                   ssh-keyscan -t rsa github.com > /etc/ssh/known_hosts
                   git config --global url."https://$GITHUB_TOKEN:@github.com/".insteadOf "https://github.com/"
-                  mv kubeconfig ./kubeaddons-tests/kubeconfig
                   make kind-test
                   """
               ],

--- a/Dispatchfile
+++ b/Dispatchfile
@@ -27,6 +27,7 @@ task("integration-test", inputs=[git],
                   export GOPRIVATE=github.com/mesosphere/kubeaddons
                   ssh-keyscan -t rsa github.com > /etc/ssh/known_hosts
                   git config --global url."https://$GITHUB_TOKEN:@github.com/".insteadOf "https://github.com/"
+                  mv kubeconfig ./kubeaddons-tests/kubeconfig
                   make kind-test
                   """
               ],

--- a/Dispatchfile
+++ b/Dispatchfile
@@ -27,6 +27,7 @@ task("integration-test", inputs=[git],
                   export GOPRIVATE=github.com/mesosphere/kubeaddons
                   ssh-keyscan -t rsa github.com > /etc/ssh/known_hosts
                   git config --global url."https://$GITHUB_TOKEN:@github.com/".insteadOf "https://github.com/"
+                  ls -a
                   make kind-test
                   """
               ],

--- a/Dispatchfile
+++ b/Dispatchfile
@@ -3,7 +3,7 @@
 load("github.com/mesosphere/dispatch-catalog/starlark/stable/pipeline@0.0.7", "cron")
 load("github.com/mesosphere/cluster-claim-controller/starlark/claim@master", "make_kind_cluster", "fetch_kubeconfig", "cleanup")
 load("github.com/mesosphere/dispatch-tasks/bump_charts/bump_charts@master", "bump_charts")
-load("github.com/mesosphere/dispatch-catalog/starlark/stable/pipeline@0.0.4", "gitResource", "pullRequest", "push", "volume", "resourceVar", "secretVar", "dindTask")
+load("github.com/mesosphere/dispatch-catalog/starlark/stable/pipeline@0.0.4", "gitResource", "pullRequest", "push", "volume", "resourceVar", "secretVar")
 
 git = "src-git"
 gitResource(git, url="$(context.git.url)", revision="$(context.git.commit)")

--- a/Dispatchfile
+++ b/Dispatchfile
@@ -27,6 +27,7 @@ task("integration-test", inputs=[git],
                   export GOPRIVATE=github.com/mesosphere/kubeaddons
                   ssh-keyscan -t rsa github.com > /etc/ssh/known_hosts
                   git config --global url."https://$GITHUB_TOKEN:@github.com/".insteadOf "https://github.com/"
+                  echo $PWD
                   ls -a
                   make kind-test
                   """

--- a/Dispatchfile
+++ b/Dispatchfile
@@ -1,7 +1,56 @@
 #!mesosphere/dispatch-starlark:v0.6
 # vi:syntax=python
 load("github.com/mesosphere/dispatch-catalog/starlark/stable/pipeline@0.0.7", "cron")
+load("github.com/mesosphere/cluster-claim-controller/starlark/claim@master", "make_kind_cluster", "fetch_kubeconfig", "cleanup")
 load("github.com/mesosphere/dispatch-tasks/bump_charts/bump_charts@master", "bump_charts")
+load("github.com/mesosphere/dispatch-catalog/starlark/stable/pipeline@0.0.4", "gitResource", "pullRequest", "push", "volume", "resourceVar", "secretVar", "dindTask")
 
+git = "src-git"
+gitResource(git, url="$(context.git.url)", revision="$(context.git.commit)")
+
+cluster_name = "kubeaddons"
+kind_cluster=make_kind_cluster(cluster_name, git)
+
+task("integration-test", inputs=[git],
+     deps=[kind_cluster],
+     steps=[
+       fetch_kubeconfig(cluster_name, git),
+       k8s.corev1.Container(
+       name = "integration-tester",
+              workingDir = "/workspace/{}/".format(git),
+              image = "mesosphere/kubeaddons-ci:latest",
+              command = ["/bin/bash", "-c"],
+              args = [
+                  """
+                  set -euo pipefail
+                  export GIT_TERMINAL_PROMPT=1
+                  export GOPRIVATE=github.com/mesosphere/kubeaddons
+                  ssh-keyscan -t rsa github.com > /etc/ssh/known_hosts
+                  git config --global url."https://$GITHUB_TOKEN:@github.com/".insteadOf "https://github.com/"
+                  make dispatch-test
+                  """
+              ],
+              resources = k8s.corev1.ResourceRequirements(
+              limits = {
+                "cpu": k8s.resource_quantity("8000m"),
+                "memory": k8s.resource_quantity("6Gi")
+              },
+              requests = {
+                "cpu": k8s.resource_quantity("500m"),
+                "memory": k8s.resource_quantity("1Gi")
+              }
+              ),
+              env=[k8s.corev1.EnvVar(name="GITHUB_TOKEN",
+                                     valueFrom=secretVar("d2iq-dispatch-github-personal-access-token",
+                                                         "GITHUB_TOKEN"))
+                  ]
+            )
+     ]
+)
+
+kind_cleanup = cleanup(kind_cluster, "integration-test", git)
 do_bump_charts = bump_charts(repo_name="kubeaddons-enterprise", task_name="bump-charts")
+
 action(name="bump-charts", on=cron(schedule="0 3 * * 5"), tasks=[do_bump_charts])
+action(tasks=["integration-test", kind_cleanup], on=pullRequest())
+

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
+	ifeq ("$(wildcard ./kubeconfig)", "")
+	  mv ./kubeaddons ./kubeaddons-tests/kubeconfig
+	endif
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
+	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && \
 	-mv kubeconfig /kubeaddons-tests/kubeconfig
 	ls -a
 	ls -a /kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ ARTIFACTS=dist
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
 	-mv kubeconfig /kubeaddons-tests/kubeconfig
+	ls -a
+	ls -a /kubeaddons-tests
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && \
-	-mv kubeconfig /kubeaddons-tests/kubeconfig
 	ls -a
+	-mv kubeconfig /kubeaddons-tests/kubeconfig
 	ls -a /kubeaddons-tests
 
 .PHONY: kind-test

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	ifeq ("$(wildcard ./kubeconfig)", "")
+	ifneq (,"$(wildcard kubeconfig)")
 	  mv ./kubeaddons ./kubeaddons-tests/kubeconfig
 	endif
 

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,11 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && \
+	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
 	ls -a
-	-mv kubeconfig /kubeaddons-tests/kubeconfig
+	echo $pwd
 	ls -a /kubeaddons-tests
+	echo $pwd
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch; \
-	ls -a ;\
-	cd .. ;\
-	ls -a ;\
-	mv kubeconfig /kubeaddons-tests/kubeconfig
+	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
+	@ls -a
+	@cd ..
+	@ls -a
+	@mv kubeconfig /kubeaddons-tests/kubeconfig
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
+	-mv kubeconfig /kubeaddons-tests/kubeconfig
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,7 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	ifneq (,"$(wildcard kubeconfig)")
-	  mv ./kubeaddons ./kubeaddons-tests/kubeconfig
-	endif
+	test -f kubeaddons && mv kubeaddons /kubeaddons-tests/kubeaddons
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,10 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	echo $(shell pwd)
-	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	echo $(shell pwd)
-	ls -a
-	echo "Getting out of the clone dir"
-	cd ..
-	echo $(shell pwd)
-	ls -a
+	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch; \
+	ls -a ;\
+	cd .. ;\
+	ls -a ;\
 	mv kubeconfig /kubeaddons-tests/kubeconfig
 
 .PHONY: kind-test

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && cd .. && ls -a &&  [ ! -f kubeconfig ] || mv kubeconfig kubeaddons-tests/kubeconfig
+	ls -a && git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && cd .. && ls -a &&  [ ! -f kubeconfig ] || mv kubeconfig kubeaddons-tests/kubeconfig
 .PHONY: kind-test
 kind-test: kubeaddons-tests
 	make -f kubeaddons-tests/Makefile kind-test

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-        echo $pwd
+	echo $pwd
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
 	echo $pwd
 	ls -a

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	echo $PWD
+	echo $(shell pwd)
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	echo $PWD
+	echo $(shell pwd)
 	ls -a
 	echo "Getting out of the clone dir"
 	cd ..
-	echo $PWD
+	echo $(shell pwd)
 	ls -a
 	mv kubeconfig /kubeaddons-tests/kubeconfig
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	bash -c test -f kubeconfig && mv kubeconfig /kubeaddons-tests/kubeconfig
+	/bin/sh -c "test -f kubeconfig && mv kubeconfig /kubeaddons-tests/kubeconfig"
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	test -f kubeconfig && mv kubeconfig /kubeaddons-tests/kubeconfig
+	bash -c test -f kubeconfig && mv kubeconfig /kubeaddons-tests/kubeconfig
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,7 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	@ls -a
-	@cd ..
-	@ls -a
-	@mv kubeconfig /kubeaddons-tests/kubeconfig
+	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && mv ../kubeconfig kubeconfig
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	echo $pwd
+	echo $PWD
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	echo $pwd
+	echo $PWD
 	ls -a
 	echo "Getting out of the clone dir"
 	cd ..
-	echo $pwd
+	echo $PWD
 	ls -a
 	mv kubeconfig /kubeaddons-tests/kubeconfig
 

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,7 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	ls -a
-	echo $pwd
-	ls -a /kubeaddons-tests
-	echo $pwd
+	mv ../kubeconfig ./kubeconfig
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && ls -a .. && mv ../kubeconfig kubeconfig
-
+	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && cd .. && ls -a &&  [ ! -f kubeconfig ] || mv kubeconfig kubeaddons-tests/kubeconfig
 .PHONY: kind-test
 kind-test: kubeaddons-tests
 	make -f kubeaddons-tests/Makefile kind-test

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,6 @@ endif
 .PHONY: clean
 clean:
 ifneq (,$(wildcard kubeaddons-tests/Makefile))
-	make -f kubeaddons-tests/Makefile clean
+	make -C kubeaddons-tests clean
 endif
 	rm -rf kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
+        echo $pwd
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	echo &pwd
+	echo $pwd
 	ls -a
+	echo "Getting out of the clone dir"
 	cd ..
 	echo $pwd
 	ls -a

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,12 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	mv ../kubeconfig ./kubeconfig
+	echo &pwd
+	ls -a
+	cd ..
+	echo $pwd
+	ls -a
+	mv kubeconfig /kubeaddons-tests/kubeconfig
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	ls -a && git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && [ ! -f kubeconfig ] || mv kubeconfig kubeaddons-tests/kubeconfig
+	ls -a && git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && [ ! -f kubeconfig ] || cp kubeconfig kubeaddons-tests/kubeconfig
 .PHONY: kind-test
 kind-test: kubeaddons-tests
 	make -f kubeaddons-tests/Makefile kind-test

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && mv ../kubeconfig kubeconfig
+	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && ls -a .. && mv ../kubeconfig kubeconfig
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	ls -a && git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && cd .. && ls -a &&  [ ! -f kubeconfig ] || mv kubeconfig kubeaddons-tests/kubeconfig
+	ls -a && git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && [ ! -f kubeconfig ] || mv kubeconfig kubeaddons-tests/kubeconfig
 .PHONY: kind-test
 kind-test: kubeaddons-tests
 	make -f kubeaddons-tests/Makefile kind-test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-KUTTL_VERSION=0.5.0
+KUTTL_VERSION=0.6.1
 KIND_VERSION=0.8.1
 KUBERNETES_VERSION ?= 1.17.5
-KUBECONFIG=kubeconfig
+KUBECONFIG?="kubeconfig"
 
 OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 MACHINE=$(shell uname -m)
@@ -14,16 +14,55 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 
 ARTIFACTS=dist
 
+bin/kind_$(KIND_VERSION):
+	mkdir -p bin/
+	curl -Lo bin/kind_$(KIND_VERSION) https://github.com/kubernetes-sigs/kind/releases/download/v$(KIND_VERSION)/kind-$(OS)-$(KIND_MACHINE)
+	chmod +x bin/kind_$(KIND_VERSION)
+
+bin/kind: bin/kind_$(KIND_VERSION)
+	ln -sf ./kind_$(KIND_VERSION) bin/kind
+
+bin/kubectl-kuttl_$(KUTTL_VERSION):
+	mkdir -p bin/
+	curl -Lo bin/kubectl-kuttl_$(KUTTL_VERSION) https://github.com/kudobuilder/kuttl/releases/download/v$(KUTTL_VERSION)/kubectl-kuttl_$(KUTTL_VERSION)_$(OS)_$(MACHINE)
+	chmod +x bin/kubectl-kuttl_$(KUTTL_VERSION)
+
+bin/kubectl-kuttl: bin/kubectl-kuttl_$(KUTTL_VERSION)
+	ln -sf ./kubectl-kuttl_$(KUTTL_VERSION) bin/kubectl-kuttl
+
+.PHONY: install-bin
+install-bin: bin/kind bin/kubectl-kuttl
+
+.PHONY: create-kind-cluster
+create-kind-cluster: $(KUBECONFIG)
+
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
 
+$(KUBECONFIG): install-bin
+ifeq ($(KUBECONFIG), "kubeconfig")
+	bin/kind create cluster --wait 10s --image=kindest/node:v$(KUBERNETES_VERSION)
+endif
+
 .PHONY: kind-test
-kind-test: kubeaddons-tests
-	make -f kubeaddons-tests/Makefile kind-test
+kind-test: kubeaddons-tests create-kind-cluster
+	kubeaddons-tests/run-tests.sh
 
 .PHONY: clean
 clean:
-ifneq (,$(wildcard kubeaddons-tests/Makefile))
-	make -f kubeaddons-tests/Makefile clean
-endif
+	bin/kind delete cluster
 	rm -rf kubeaddons-tests
+	
+bin/kubectl-kuttl_$(KUTTL_VERSION):
+	mkdir -p bin/
+	curl -Lo bin/kubectl-kuttl_$(KUTTL_VERSION) https://github.com/kudobuilder/kuttl/releases/download/v$(KUTTL_VERSION)/kubectl-kuttl_$(KUTTL_VERSION)_$(OS)_$(MACHINE)
+	chmod +x bin/kubectl-kuttl_$(KUTTL_VERSION)
+	
+bin/kubectl-kuttl: bin/kubectl-kuttl_$(KUTTL_VERSION)
+	ln -sf ./kubectl-kuttl_$(KUTTL_VERSION) bin/kubectl-kuttl
+
+.PHONY: dispatch-test
+dispatch-test: bin/kubectl-kuttl
+	KUBEADDONS_TESTS_KUBECONFIG=/workspace/src-git/kubeconfig
+	git clone https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
+	kubeaddons-tests/run-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,15 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch 
+	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
 	ls -a
 	@if [ -f kubeconfig ]; then\
 		cp kubeconfig kubeaddons-tests/kubeconfig && ls -a ./kubeaddons-tests; \
 	fi
+
 .PHONY: kind-test
 kind-test: kubeaddons-tests
-	make -f kubeaddons-tests/Makefile kind-test
+	$(MAKE) -C kubeaddons-tests kind-test
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	ls -a && git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && [ ! -f kubeconfig ] || cp kubeconfig kubeaddons-tests/kubeconfig
+	ls -a && git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && [ ! -f kubeconfig ] || cp kubeconfig kubeaddons-tests/kubeconfig && ls -a ./kubeaddons-tests
 .PHONY: kind-test
 kind-test: kubeaddons-tests
 	make -f kubeaddons-tests/Makefile kind-test

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ export PATH := $(shell pwd)/bin/:$(PATH)
 ARTIFACTS=dist
 
 kubeaddons-tests:
-	ls -a && git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch && ls -a && [ ! -f kubeconfig ] || cp kubeconfig kubeaddons-tests/kubeconfig && ls -a ./kubeaddons-tests
+	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch 
+	ls -a
+	@if [ -f kubeconfig ]; then\
+		cp kubeconfig kubeaddons-tests/kubeconfig && ls -a ./kubeaddons-tests; \
+	fi
 .PHONY: kind-test
 kind-test: kubeaddons-tests
 	make -f kubeaddons-tests/Makefile kind-test
@@ -28,7 +32,7 @@ endif
 	rm -rf kubeaddons-tests
 
 .PHONY: dispatch-test
-dispatch-test: 
+dispatch-test:
 	mkdir -p bin/
 	curl -Lo bin/kubectl-kuttl_$(KUTTL_VERSION) https://github.com/kudobuilder/kuttl/releases/download/v$(KUTTL_VERSION)/kubectl-kuttl_$(KUTTL_VERSION)_$(OS)_$(MACHINE)
 	chmod +x bin/kubectl-kuttl_$(KUTTL_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,13 @@ kubeaddons-tests:
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests
+ifeq (,$(wildcard kubeconfig))
 	$(MAKE) -C kubeaddons-tests kind-test
+else
+	$(MAKE) -C kubeaddons-tests bin/kubectl-kuttl
+	$(MAKE) -o kubeconfig -C kubeaddons-tests kind-test
+endif
+
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,3 @@ ifneq (,$(wildcard kubeaddons-tests/Makefile))
 	make -f kubeaddons-tests/Makefile clean
 endif
 	rm -rf kubeaddons-tests
-
-.PHONY: dispatch-test
-dispatch-test:
-	mkdir -p bin/
-	curl -Lo bin/kubectl-kuttl_$(KUTTL_VERSION) https://github.com/kudobuilder/kuttl/releases/download/v$(KUTTL_VERSION)/kubectl-kuttl_$(KUTTL_VERSION)_$(OS)_$(MACHINE)
-	chmod +x bin/kubectl-kuttl_$(KUTTL_VERSION)
-	ln -sf ./kubectl-kuttl_$(KUTTL_VERSION) bin/kubectl-kuttl
-	KUBEADDONS_TESTS_KUBECONFIG=/workspace/src-git/kubeconfig
-	git clone https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	kubeaddons-tests/run-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	/bin/sh -c "test -f kubeconfig && mv kubeconfig /kubeaddons-tests/kubeconfig"
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 
 .PHONY: dispatch-test
 dispatch-test: 
-        mkdir -p bin/
+	mkdir -p bin/
 	curl -Lo bin/kubectl-kuttl_$(KUTTL_VERSION) https://github.com/kudobuilder/kuttl/releases/download/v$(KUTTL_VERSION)/kubectl-kuttl_$(KUTTL_VERSION)_$(OS)_$(MACHINE)
 	chmod +x bin/kubectl-kuttl_$(KUTTL_VERSION)
 	ln -sf ./kubectl-kuttl_$(KUTTL_VERSION) bin/kubectl-kuttl

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ARTIFACTS=dist
 
 kubeaddons-tests:
 	git clone --depth 1 https://github.com/mesosphere/kubeaddons-tests.git --branch master --single-branch
-	test -f kubeaddons && mv kubeaddons /kubeaddons-tests/kubeaddons
+	test -f kubeconfig && mv kubeconfig /kubeaddons-tests/kubeconfig
 
 .PHONY: kind-test
 kind-test: kubeaddons-tests


### PR DESCRIPTION
Adds Dispatchfile integration and runs make targets using `-C` 

For tests it will go through the following flow:

1 check to see if there's a file called kubeconfig there
2 if its not call the make target normally
3 if it is download kuttl and use the old -o (passed from directory above)  kubeconfig

This can be helpful if you have a kubeconfig already and want to test these changes against that cluster rather than a new kind cluster.