### PR TITLE
Fixes the params link in older Cassandra versions

### DIFF
--- a/addons/cassandra/0.x/cassandra-1.yaml
+++ b/addons/cassandra/0.x/cassandra-1.yaml
@@ -10,6 +10,7 @@ metadata:
     catalog.kubeaddons.mesosphere.io/addon-revision: "3.11.5-1"
     appversion.kubeaddons.mesosphere.io/cassandra: "3.11.5"
     stage.kubeaddons.mesosphere.io/cassandra: Beta
+    catalog.kubeaddons.mesosphere.io/kudo-params: "https://raw.githubusercontent.com/mesosphere/kudo-cassandra-operator/v3.11.5-0.1.1/operator/params.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.16.0
@@ -25,5 +26,5 @@ spec:
   kudoReference:
     package: cassandra
     repo: https://kudo-repository.storage.googleapis.com/0.10.0
-    version: 0.1.2
+    version: 0.1.1
     appVersion: 3.11.5

--- a/addons/cassandra/0.x/cassandra-2.yaml
+++ b/addons/cassandra/0.x/cassandra-2.yaml
@@ -10,7 +10,7 @@ metadata:
     catalog.kubeaddons.mesosphere.io/addon-revision: "3.11.5-2"
     appversion.kubeaddons.mesosphere.io/cassandra: "3.11.5"
     stage.kubeaddons.mesosphere.io/cassandra: Beta
-    catalog.kubeaddons.mesosphere.io/kudo-params: "https://raw.githubusercontent.com/kudobuilder/operators/master/repository/cassandra/3.11/operator/params.yaml"
+    catalog.kubeaddons.mesosphere.io/kudo-params: "https://raw.githubusercontent.com/mesosphere/kudo-cassandra-operator/v3.11.5-0.1.2/operator/params.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.16.0

--- a/addons/cassandra/1.x/cassandra-1.yaml
+++ b/addons/cassandra/1.x/cassandra-1.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "3.11.6-1"
     appversion.kubeaddons.mesosphere.io/cassandra: "3.11.6"
-    catalog.kubeaddons.mesosphere.io/kudo-params: "https://raw.githubusercontent.com/kudobuilder/operators/master/repository/cassandra/3.11/operator/params.yaml"
+    catalog.kubeaddons.mesosphere.io/kudo-params: "https://raw.githubusercontent.com/mesosphere/kudo-cassandra-operator/v3.11.6-1.0.0/operator/params.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.16.0


### PR DESCRIPTION
Previous Cassandra versions are not referring to the correct parameters link, so they all are pointing only latest changes. It creates a problem such as while installing Cassandra 3.11.5, it will be installed with the image of Cassandra 3.11.6.

This PR will fix the problem by referring to the correct tag in the parameters link.