### PR TITLE
Fix Spark 2.4.5 params.yml reference

### DIFF
--- a/addons/spark/1.x/spark-2.yaml
+++ b/addons/spark/1.x/spark-2.yaml
@@ -10,7 +10,7 @@ metadata:
     catalog.kubeaddons.mesosphere.io/certification: "Certified, Supported"
     catalog.kubeaddons.mesosphere.io/addon-revision: "2.4.5-2"
     appversion.kubeaddons.mesosphere.io/spark: "2.4.5"
-    catalog.kubeaddons.mesosphere.io/kudo-params: "https://raw.githubusercontent.com/kudobuilder/operators/master/repository/spark/operator/params.yaml"
+    catalog.kubeaddons.mesosphere.io/kudo-params: "https://raw.githubusercontent.com/kudobuilder/operators/d4cbfc347069d1e1f2795525a2c3e04e90b3d8a3/repository/spark/operator/params.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/addons/spark/1.x/spark-2.yaml
+++ b/addons/spark/1.x/spark-2.yaml
@@ -32,6 +32,6 @@ spec:
   kudoReference:
     package: spark
     repo: https://kudo-repository.storage.googleapis.com/0.10.0
-    version: 1.0.0
+    version: 1.0.1
     parameters: |
       enableMetrics: true


### PR DESCRIPTION
Fix Spark 2.4.5 to use the params.yml file associated with [Spark Operator 1.0.1 Release](https://github.com/kudobuilder/operators/commit/d4cbfc347069d1e1f2795525a2c3e04e90b3d8a3)