### PR TITLE
[auto-bump][chart] prometheus-elasticsearch-exporter-4.4.0

### DIFF
--- a/addons/elasticsearch-exporter/1.1.x/elasticsearch-exporter-1.yaml
+++ b/addons/elasticsearch-exporter/1.1.x/elasticsearch-exporter-1.yaml
@@ -6,10 +6,10 @@ metadata:
     kubeaddons.mesosphere.io/name: elasticsearch-exporter
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/certification: '["certified"]'
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-4"
+    catalog.kubeaddons.mesosphere.io/certification: '-1'
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-5"
     appversion.kubeaddons.mesosphere.io/elasticsearch-exporter: "1.1.0"
-    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch-exporter: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch-exporter/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch-exporter: "https://raw.githubusercontent.com/mesosphere/charts/08e4e67/stable/elasticsearch-exporter/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: prometheus-elasticsearch-exporter
     repo: https://prometheus-community.github.io/helm-charts
-    version: 4.0.0
+    version: 4.4.0
     values: |
       ---
       #fullnameOverride: ""


### PR DESCRIPTION

        ##### Add Release Notes or "None":

        ```release-note

        ```
        This is automated bump triggered from the source repo containing the updated Chart/Addon.
        