### PR TITLE
[auto-bump][chart] prometheus-elasticsearch-exporter-4.15.1

### DIFF
--- a/addons/elasticsearch-exporter/1.5.x/elasticsearch-exporter-1.yaml
+++ b/addons/elasticsearch-exporter/1.5.x/elasticsearch-exporter-1.yaml
@@ -7,30 +7,30 @@ metadata:
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
     catalog.kubeaddons.mesosphere.io/certification: '["certified"]'
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-4"
-    appversion.kubeaddons.mesosphere.io/elasticsearch-exporter: "1.1.0"
-    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch-exporter: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch-exporter/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.0-1"
+    appversion.kubeaddons.mesosphere.io/elasticsearch-exporter: "1.5.0"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch-exporter: "https://raw.githubusercontent.com/mesosphere/charts/519a236/stable/elasticsearch-exporter/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
   cloudProvider:
-  - name: aws
-    enabled: true
-  - name: azure
-    enabled: true
-  - name: gcp
-    enabled: true
-  - name: docker
-    enabled: false
-  - name: none
-    enabled: true
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: true
   requires:
-  - matchLabels:
-      kubeaddons.mesosphere.io/name: elasticsearch-oss
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: elasticsearch-oss
   chartReference:
     chart: prometheus-elasticsearch-exporter
     repo: https://prometheus-community.github.io/helm-charts
-    version: 4.0.0
+    version: 4.15.1
     values: |
       ---
       #fullnameOverride: ""

--- a/addons/elasticsearch-exporter/1.5.x/elasticsearch-exporter-1.yaml
+++ b/addons/elasticsearch-exporter/1.5.x/elasticsearch-exporter-1.yaml
@@ -1,0 +1,44 @@
+apiVersion: kubeaddons.mesosphere.io/v1beta2
+kind: Addon
+metadata:
+  name: elasticsearch-exporter
+  labels:
+    kubeaddons.mesosphere.io/name: elasticsearch-exporter
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
+  annotations:
+    catalog.kubeaddons.mesosphere.io/certification: '["certified"]'
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-4"
+    appversion.kubeaddons.mesosphere.io/elasticsearch-exporter: "1.1.0"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch-exporter: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch-exporter/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.0
+  cloudProvider:
+  - name: aws
+    enabled: true
+  - name: azure
+    enabled: true
+  - name: gcp
+    enabled: true
+  - name: docker
+    enabled: false
+  - name: none
+    enabled: true
+  requires:
+  - matchLabels:
+      kubeaddons.mesosphere.io/name: elasticsearch-oss
+  chartReference:
+    chart: prometheus-elasticsearch-exporter
+    repo: https://prometheus-community.github.io/helm-charts
+    version: 4.0.0
+    values: |
+      ---
+      #fullnameOverride: ""
+      #nameOverride: ""
+      es:
+        uri: http://elasticsearch-oss-client:9200
+      service:
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+        metricsPort:
+          name: metrics


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        